### PR TITLE
Add partial close example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ const hash = await nftperp.closePosition({
 });
 ```
 
+#### Partially close position
+
+```ts
+const hash = await nftperp.closePosition({
+    amm: Amm.BAYC,
+    closePercent: 0.5, // 50%
+});
+```
+
 #### Estimate fee on position
 
 ```ts


### PR DESCRIPTION
The percentage has to be in [0, 1] and not in [0, 100] as the "close position transaction summary" example might suggest.