### PR TITLE
fix(BalancesResponse): updated type to match response

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -115,8 +115,16 @@ export type TotalPositionSizeResponse = {
 };
 
 export type BalancesResponse = {
-    eth: string;
-    weth: string;
+    arb: {
+        eth: string;
+        weth: string;
+        approvedAmount: string;
+    };
+    blast: {
+        eth: string;
+        weth: string;
+        approvedAmount: string;
+    };
 };
 
 export interface TxInfo {


### PR DESCRIPTION
The response of the getBalances API call of the SDK also returns the chain names ("arb" and "blast") as well as the "approvedAmount" per chain, so I added that to the BalancesResponse type